### PR TITLE
chore: Add EntityAddTool to tools/__init__.py and tests

### DIFF
--- a/examples/rag_with_fact_memory.py
+++ b/examples/rag_with_fact_memory.py
@@ -1,0 +1,160 @@
+import dspy
+from hybridagi import GraphProgramInterpreter
+from hybridagi import SentenceTransformerEmbeddings
+from hybridagi import ProgramMemory, FactMemory
+from hybridagi.tools import EntityAddTool
+from pydantic import BaseModel
+from dspy.teleprompt import BootstrapFewShot
+
+print("Loading LLM & embeddings models...")
+student_llm = dspy.OllamaLocal(model='mistral', max_tokens=1024, stop=["\n\n\n"])
+teacher_llm = dspy.OllamaLocal(model='mistral', max_tokens=1024, stop=["\n\n\n"])
+
+embeddings = SentenceTransformerEmbeddings(dim=384, model_name_or_path="sentence-transformers/all-MiniLM-L6-v2")
+
+dspy.settings.configure(lm=student_llm)
+
+model_path = "rag_with_fact_memory.json"
+
+class AssessAnswer(dspy.Signature):
+    """Assess the success of the trace according to the objective"""
+    assessed_answer = dspy.InputField(desc="The answer to assess")
+    assessed_question = dspy.InputField(desc="The question to be assessed")
+    critique = dspy.OutputField(desc="The critique of the answer")
+
+class Score(BaseModel):
+    score: float
+
+class CritiqueToScoreSignature(dspy.Signature):
+    """Convert a critique into a score between 0.0 and 1.0"""
+    critique = dspy.InputField(desc="The critique to convert into a score")
+    score: Score = dspy.OutputField(desc="A score between 0.0 and 1.0")
+
+def program_success(example, pred, trace=None):
+    question = example.objective
+    with dspy.context(lm=teacher_llm):
+        prediction = dspy.ChainOfThought(AssessAnswer)(
+            assessed_answer = pred.final_answer,
+            assessed_question = question,
+        )
+        result = dspy.TypedPredictor(CritiqueToScoreSignature)(critique=prediction.critique)
+    return result.score.score
+
+print("Initializing the program memory...")
+program_memory = ProgramMemory(
+    index_name = "rag_with_fact_memory",
+    embeddings = embeddings,
+    wipe_on_start = True,
+)
+
+print("Initializing the fact memory...")
+fact_memory = FactMemory(
+    index_name = "rag_with_fact_memory",
+    embeddings = embeddings,
+    wipe_on_start = True,
+)
+
+print("Adding Cypher programs into the program memory...")
+program_memory.add_texts(
+    texts = [
+"""
+// @desc: The main program
+CREATE
+(start:Control {name:"Start"}),
+(end:Control {name:"End"}),
+(entity_add:Action {
+    name: "Create a fact memory entity based on the objective's question",
+    tool: "EntityAdd",
+    prompt: "Use the objective's question to infer triplets and add them to the fact memory"
+}),
+(start)-[:NEXT]->(entity_add),
+(entity_add)-[:NEXT]->(end)
+""",
+    ],
+    ids = [
+        "main",
+    ]
+)
+
+documents_texts = """
+SynaLinks is a young French start-up founded in Toulouse in 2023.
+Our mission is to promote a responsible and pragmatic approach to general artificial intelligence.
+To achieve this, we integrate deep learning models with symbolic artificial intelligence models, the traditional domain of AI before the era of deep learning.
+
+At SynaLinks, our approach aims to combine the efficiency of deep learning models with the transparency and explicability of symbolic models, thus creating more robust and ethical artificial intelligence systems. 
+We work on cutting-edge technologies that enable businesses to fully harness the potential of AI while retaining significant control over their systems, reducing the risks associated with opacity and dependence on deep learning algorithms.
+
+We work closely with our clients to customize our solutions to meet their specific needs.
+Our neuro-symbolic approach offers the flexibility necessary to address the diverse requirements of businesses, allowing them to remain masters of their AI.
+
+We are confident that AI can be a positive force for society and the economy,rather than a source of concern.
+We are committed to playing an active role in promoting responsible AI use while contributing to the advancement of the fourth industrial revolution.
+
+As a start-up based in Toulouse, we take pride in being part of the French technological ecosystem and contributing to innovation in the field of AI.
+Our future is centered on ongoing research, improving our products and services, and creating a world where AI is a driver of progress, ethics, and profitability for businesses.
+"""
+
+dataset = []
+documents = documents_texts.split("\n\n")
+train_size = int(0.8 * len(documents))
+for i, document_text in enumerate(documents):
+    if i < train_size:
+        dataset.append(
+            dspy.Example(objective=document_text).with_inputs("objective")
+        )
+    else:
+        testset = [
+            dspy.Example(objective=document_text).with_inputs("objective")
+        ]
+
+tools = [
+    EntityAddTool(
+        fact_memory = fact_memory,
+        embeddings = embeddings,
+    )
+]
+
+print("Optimizing underlying prompts...")
+config = dict(max_bootstrapped_demos=4, max_labeled_demos=0)
+
+optimizer = BootstrapFewShot(
+    teacher_settings=dict({'lm': teacher_llm}),
+    metric = program_success,
+    **config,
+)
+
+interpreter = GraphProgramInterpreter(
+    program_memory = program_memory,
+    tools = tools,
+)
+
+compiled_interpreter = optimizer.compile(
+    interpreter,
+    trainset=dataset,
+    valset=testset,
+)
+
+evaluate = dspy.evaluate.Evaluate(
+    devset = testset,
+    metric = program_success,
+    num_threads = 1,
+    display_progress = True,
+    display_table = 0,
+)
+
+print("Evaluate baseline model")
+try:
+    baseline_score = evaluate(interpreter)
+except Exception:
+    baseline_score = 0.0
+print("Evaluate optimized model")
+try:
+    eval_score = evaluate(compiled_interpreter)
+except Exception:
+    eval_score = 0.0
+
+print(f"Baseline: {baseline_score}")
+print(f"Score: {eval_score}")
+
+print(f"Save optimized model to '{model_path}'")
+compiled_interpreter.save(model_path)

--- a/hybridagi/tools/__init__.py
+++ b/hybridagi/tools/__init__.py
@@ -25,6 +25,7 @@ from .clear_trace import ClearTraceTool
 from .revert_trace import RevertTraceTool
 
 from .query_facts import QueryFactsTool
+from .entity_add import EntityAddTool
 
 from .code_interpreter import CodeInterpreterTool
 from .browse_website import BrowseWebsiteTool
@@ -58,6 +59,7 @@ __all__ = [
     RevertTraceTool,
 
     QueryFactsTool,
+    EntityAddTool,
 
     CodeInterpreterTool,
     BrowseWebsiteTool,

--- a/hybridagi/tools/entity_add.py
+++ b/hybridagi/tools/entity_add.py
@@ -1,0 +1,120 @@
+import dspy
+import re
+from typing import Optional, List
+from .base import BaseTool
+from ..output_parsers.prediction import PredictionOutputParser
+from ..hybridstores.fact_memory.fact_memory import FactMemory
+from ..embeddings.base import BaseEmbeddings
+
+class ExtractTripletsSignature(dspy.Signature):
+    """Extract knowledge triplets from the given text."""
+    text = dspy.InputField(desc="The text to extract triplets from")
+    triplets = dspy.OutputField(desc="""A list of knowledge triplets in the format (subject, predicate, object), DO NOT add any other content
+    
+    Example:
+    London is the capital of England. Westminster is located in London.
+
+    [
+        ("Capital_of_England", "is", "London"),
+        ("Location_of_Westminster", "within", "London"),
+        ("Part_of_London", "is", "Westminster")
+    ]
+    """)
+
+class EntityAddSignature(dspy.Signature):
+    """Infer the correct document content and title based on given information."""
+    objective = dspy.InputField(desc="The long-term objective (what you are doing)")
+    context = dspy.InputField(desc="The previous actions (what you have done)")
+    purpose = dspy.InputField(desc="The purpose of the action (what you have to do now)")
+    prompt = dspy.InputField(desc="The action specific instructions (How to do it)")
+    content = dspy.OutputField(desc="The content to convert to triplets")
+
+class EntityAddTool(BaseTool):
+    def __init__(
+        self,
+        fact_memory: FactMemory,
+        embeddings: BaseEmbeddings,
+        lm: Optional[dspy.LM] = None,
+    ):
+        super().__init__(name="EntityAdd", lm=lm)
+        self.predict = dspy.Predict(EntityAddSignature)
+        self.extract_triplets = dspy.Predict(ExtractTripletsSignature)
+        self.prediction_parser = PredictionOutputParser()
+        self.fact_memory = fact_memory
+        self.embeddings = embeddings
+
+    @staticmethod
+    def clean_triplets_string(triplets_str: str) -> str:
+        """Clean the triplets string."""
+        start = triplets_str.find('[')
+        end = triplets_str.rfind(']')
+        
+        if start != -1 and end != -1 and start < end:
+            triplets_content = triplets_str[start:end+1]
+            return re.sub(r'\s+', ' ', triplets_content).strip()
+        return triplets_str.strip()
+
+    def add_triplets_to_fact_memory(self, triplets: List[tuple]) -> str:
+        """Add valid triplets to FactMemory."""
+        valid_triplets = 0
+        for subject, predicate, obj in triplets:
+            if all((subject, predicate, obj)):
+                for node in (subject, obj):
+                    self.fact_memory.add_texts(
+                        texts=[node],
+                        ids=[node],
+                        descriptions=[node],
+                    )
+                self.fact_memory.add_triplet(subject, predicate, obj)
+                valid_triplets += 1
+        
+        return f"Processed document: {valid_triplets} valid triplets added to FactMemory."
+
+    def forward(
+        self,
+        context: str,
+        objective: str,
+        purpose: str,
+        prompt: str,
+        disable_inference: bool = False,
+    ) -> dspy.Prediction:
+        """Perform DSPy forward prediction."""
+        if not disable_inference:
+            with dspy.context(lm=self.lm or dspy.settings.lm):
+                pred = self.predict(
+                    objective=objective,
+                    context=context,
+                    purpose=purpose,
+                    prompt=prompt,
+                )
+            
+            triplets_pred = self.extract_triplets(text=pred.content)
+            triplets_str = self.prediction_parser.parse(triplets_pred.triplets, prefix="", stop=["\n\n"])
+            triplets_str = self.clean_triplets_string(triplets_str)
+            
+            try:
+                pred.content = eval(triplets_str)
+                message = self.add_triplets_to_fact_memory(pred.content)
+            except Exception:
+                pred.content = triplets_str
+                message = "Error: Unable to parse triplets from LLM output. Document not processed."
+        else:
+            try:
+                triplets = eval(prompt)
+                message = self.add_triplets_to_fact_memory(triplets)
+                pred = dspy.Prediction(content=triplets)
+            except Exception:
+                pred = dspy.Prediction(content=prompt)
+                message = "Error: Unable to parse triplets from LLM output. Document not processed."
+
+        return dspy.Prediction(
+            content=pred.content,
+            message=message
+        )
+
+    def __deepcopy__(self, memo):
+        return type(self)(
+            fact_memory=self.fact_memory,
+            embeddings=self.embeddings,
+            lm=self.lm,
+        )

--- a/tests/tools/test_entity_add.py
+++ b/tests/tools/test_entity_add.py
@@ -1,0 +1,57 @@
+import dspy
+from hybridagi import FakeEmbeddings
+from hybridagi import FactMemory
+from hybridagi.tools import EntityAddTool
+from dspy.utils.dummies import DummyLM
+
+def test_tool_with_lm():
+    emb = FakeEmbeddings(dim=250)
+
+    pred_answer = """[("Capital_of_England", "is equal to", "London"), ("Location_of_Westminster", "is", "London"), ("Part_of_London", "is", "Westminster")]"""
+    extract_triple_answer = """[("Capital_of_England", "is equal to", "London"), ("Location_of_Westminster", "is", "London"), ("Part_of_London", "is", "Westminster")]"""
+    dspy.settings.configure(lm=DummyLM(answers=[pred_answer, extract_triple_answer]))
+    
+    memory = FactMemory(
+        index_name = "test",
+        embeddings = emb,
+        wipe_on_start = True,
+    )
+
+    tool = EntityAddTool(
+        fact_memory = memory,
+        embeddings = emb,
+    )
+
+    prediction = tool(
+        objective = "test objective",
+        context = "Nothing done yet",
+        purpose = "test purpose",
+        prompt = "test prompt",
+        disable_inference = False,
+    )
+
+    assert prediction.message == "Processed document: 3 valid triplets added to FactMemory."
+
+def test_tool_without_lm():
+    emb = FakeEmbeddings(dim=250)
+   
+    memory = FactMemory(
+        index_name = "test",
+        embeddings = emb,
+        wipe_on_start = True,
+    )
+
+    tool = EntityAddTool(
+        fact_memory = memory,
+        embeddings = emb,
+    )
+
+    prediction = tool(
+        objective = "test objective",
+        context = "Nothing done yet",
+        purpose = "test purpose",
+        prompt = """[("Capital_of_England", "is equal to", "London"), ("Location_of_Westminster", "is", "London"), ("Part_of_London", "is", "Westminster")]""",
+        disable_inference = True,
+    )
+
+    assert prediction.message == "Processed document: 3 valid triplets added to FactMemory."


### PR DESCRIPTION
Attempt to add entities into the fact memory using llm based parser. Previous attempt using spacy was limited https://github.com/SynaLinks/HybridAGI/pull/9 

Here is a graph view of the SynaLinks overview text converted imported into the fact memory

![graph](https://github.com/SynaLinks/HybridAGI/assets/1639010/6561260c-269b-43d5-887d-f0bf44b17fee)
