### PR TITLE
Fixes missing docker-compose config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ local_cache/
 htmlcov/
 .env
 .chainlit/.*.db
+.DS_Store
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,23 @@
+version: '3'
+services:
+  hybrid-agi-db:
+    image: falkordb/falkordb:edge
+    container_name: hybrid-agi-db
+    ports:
+      - 6379:6379
+  hybrid-agi-db-browser:
+    image: redislabs/redisinsight:1.14.0
+    container_name: hybrid-agi-db-browser
+    depends_on:
+      - hybrid-agi-db
+    ports:
+      - 8001:8001
+  hybrid-agi-sandbox:
+    image: hybrid-agi-sandbox
+    working_dir: /Workspace
+    build:
+      context: ./sandbox
+      dockerfile: Dockerfile
+    container_name: hybrid-agi-sandbox
+    ports:
+      - 8000:8000


### PR DESCRIPTION
### Bug Details

name: 'Docker Compose Issue'
about: 'Cannot run `docker compose up` from `main` branch.'
title: 'Docker Compose Issue'
labels: 'docker-compose'

---

**Describe the bug**

When pulling from `main` branch and following instructions to install from https://synalinks.github.io/documentation/docs/install, users need a docker-compose.yaml file to pull and deploy the images. Currently this file is missing on the `main` branch. 

**To Reproduce**

Steps to reproduce the behavior:

### 1. Install[​](https://synalinks.github.io/documentation/docs/install#1-install "Direct link to 1. Install")

```
git clone https://github.com/SynaLinks/HybridAGI
cd HybridAGI
virtualenv venv
source venv/bin/activate
pip install poetry # If you don't have it already
poetry install
```

### 2. Setup the Knowledge Base (needed for the system to work)[​](https://synalinks.github.io/documentation/docs/install#2-setup-the-knowledge-base-needed-for-the-system-to-work "Direct link to 2. Setup the Knowledge Base (needed for the system to work)")

```
docker compose up
```

Throws error for missing docker-compose config file.  

### Fix

This updates the main branch with the docker-compose file to run the images.