### PR TITLE
Remove self.facts reset in from_cypher

### DIFF
--- a/hybridagi/core/datatypes.py
+++ b/hybridagi/core/datatypes.py
@@ -151,7 +151,6 @@ class FactList(BaseModel, dspy.Prediction):
     
     def from_cypher(self, cypher_facts: str, metadata: Dict[str, Any] = {}):
         triplets = re.findall(CYPHER_FACT_REGEX, cypher_facts)
-        self.facts = []
         for triplet in triplets:
             subject_label, subject_name, predicate, object_label, object_name = triplet
             self.facts.append(Fact(

--- a/tests/core/test_datatypes.py
+++ b/tests/core/test_datatypes.py
@@ -124,3 +124,26 @@ def test_interaction_session_with_chat():
     session.chat.msgs.append(dt.Message(role=dt.Role.User, content="Can you tell me what is the capital of France?"))
     assert session.chat.msgs[0].content == "Hello, I'm an AI assistant what can I do to help you?"
     assert session.chat.msgs[1].content == "Can you tell me what is the capital of France?"
+
+def test_fact_list_from_cypher():
+    cypher_facts = """
+    (:Person {name:"John"})-[:KNOWS]->(:Person {name:"Jane"}),
+    (:City {name:"New York"})-[:LOCATED_IN]->(:Country {name:"USA"})
+    """
+    fact_list = dt.FactList().from_cypher(cypher_facts)
+    
+    assert len(fact_list.facts) == 2
+    
+    # Test first fact
+    assert fact_list.facts[0].subj.label == "Person"
+    assert fact_list.facts[0].subj.name == "John"
+    assert fact_list.facts[0].rel.name == "KNOWS"
+    assert fact_list.facts[0].obj.label == "Person"
+    assert fact_list.facts[0].obj.name == "Jane"
+    
+    # Test second fact
+    assert fact_list.facts[1].subj.label == "City"
+    assert fact_list.facts[1].subj.name == "New York"
+    assert fact_list.facts[1].rel.name == "LOCATED_IN"
+    assert fact_list.facts[1].obj.label == "Country"
+    assert fact_list.facts[1].obj.name == "USA"

--- a/tests/modules/extractors/test_llm_fact_extractor.py
+++ b/tests/modules/extractors/test_llm_fact_extractor.py
@@ -1,0 +1,56 @@
+import dspy
+from hybridagi.modules.extractors.llm_fact_extractor import LLMFactExtractor
+from hybridagi.core.datatypes import Document, DocumentList, FactList
+
+from dspy.utils.dummies import DummyLM
+
+def test_llm_fact_extractor_with_document():
+    answers = ['(:Person {name:"Bob"})-[:KNOWS]->(:Person {name:"Alice"})']
+    dspy.settings.configure(lm=DummyLM(answers=answers))
+
+    extractor = LLMFactExtractor()
+
+    doc = Document(text="Bob knows Alice.")
+    result = extractor.forward(doc)
+
+    assert isinstance(result, FactList)
+    assert len(result.facts) == 1
+    assert result.facts[0].subj.label == "Person"
+    assert result.facts[0].subj.name == "Bob"
+    assert result.facts[0].rel.name == "KNOWS"
+    assert result.facts[0].obj.label == "Person"
+    assert result.facts[0].obj.name == "Alice"
+
+def test_llm_fact_extractor_with_document_list():
+    answers = [
+        '(:Person {name:"John"})-[:LIKES]->(:Fruit {name:"apples"})',
+        '(:Person {name:"Mary"})-[:HATES]->(:Fruit {name:"bananas"})'
+    ]
+    dspy.settings.configure(lm=DummyLM(answers=answers))
+    
+    extractor = LLMFactExtractor()
+    
+    docs = DocumentList(docs=[
+        Document(text="John likes apples."),
+        Document(text="Mary hates bananas.")
+    ])
+    result = extractor.forward(docs)
+    
+    assert isinstance(result, FactList)
+    assert len(result.facts) == 2
+    assert result.facts[0].subj.name == "John"
+    assert result.facts[0].rel.name == "LIKES"
+    assert result.facts[0].obj.name == "apples"
+    assert result.facts[1].subj.name == "Mary"
+    assert result.facts[1].rel.name == "HATES"
+    assert result.facts[1].obj.name == "bananas"
+
+def test_llm_fact_extractor_with_invalid_input():
+    extractor = LLMFactExtractor()
+    
+    try:
+        extractor.forward("Invalid input")
+    except ValueError as e:
+        assert str(e) == "LLMFactExtractor input must be a Document or DocumentList"
+    else:
+        assert False, "ValueError was not raised"


### PR DESCRIPTION
Currently the LLMFactExtractor forward logic is creating a FactList with only facts extracted from the last document.

There might be a better way of dealing with this situation but wanted to bring it  up. I can add unit testing for it  if this makes sense.